### PR TITLE
Fix issue with single character disappearing when at the start of a template

### DIFF
--- a/templates.nim
+++ b/templates.nim
@@ -54,14 +54,13 @@ proc trim_eol(value: var string) {.compiletime.} =
             value = value.substr(0, i)
             break
 
-        # This is the first character
-        if i == 0:
-            value = ""
-            break
-
         # Skip change
         if not (value[i] in [' ', '\t']): break
 
+        # This is the first character, and it's not whitespace
+        if i == 0:
+            value = ""
+            break
 
 proc detect_indent(value: string, index: int): int {.compiletime.} =
     ## Detects how indented the line at `index` is.

--- a/templates.nim
+++ b/templates.nim
@@ -122,7 +122,7 @@ iterator parse_compound_statements(value, identifier: string, index: int): strin
     ## and returns the initialization of each as an empty statement
     ## i.e. if x == 5 { ... } becomes if x == 5: nil.
 
-    template get_next_ident(expected): stmt =
+    template get_next_ident(expected): typed =
         var nextIdent: string
         discard value.parseWhile(nextIdent, {'$'} + identChars, i)
 
@@ -315,14 +315,14 @@ proc parse_template(node: NimNode, value: string) =
           parse_until_symbol(node, value, index): discard
 
 when not defined(js):
-    macro tmplf*(body: expr): stmt =
+    macro tmplf*(body: untyped): typed =
         result = newStmtList()
         result.add parseExpr("result = \"\"")
         var value = readFile(body.strVal)
         parse_template(result, reindent(value))
-    
-    
-macro tmpli*(body: expr): stmt =
+
+
+macro tmpli*(body: untyped): typed =
     result = newStmtList()
 
     result.add parseExpr("result = \"\"")
@@ -333,7 +333,7 @@ macro tmpli*(body: expr): stmt =
     parse_template(result, reindent(value))
 
 
-macro tmpl*(body: expr): stmt =
+macro tmpl*(body: untyped): typed =
     result = newStmtList()
 
     var value = if body.kind in nnkStrLit..nnkTripleStrLit: body.strVal

--- a/templates/annotate.nim
+++ b/templates/annotate.nim
@@ -1,7 +1,7 @@
 import macros, parseutils
 
 # Generate tags
-macro make(names: openarray[expr]): stmt {.immediate.} =
+macro make(names: varargs[untyped]): typed =
     result = newStmtList()
 
     for i in 0 .. names.len-1:
@@ -62,4 +62,4 @@ proc reindent*(value: string, preset_indent = 0): string =
 
 
 #Define tags
-make([ html, xml, glsl, js, css, rst, md, nim ])
+make(html, xml, glsl, js, css, rst, md, nim)

--- a/tests/templates_tests.nim
+++ b/tests/templates_tests.nim
@@ -62,6 +62,16 @@ when true:
         echo actual()
         assert actual() == expected
 
+    block:
+        # regression test: there was an issue where if the template started with
+        # a single character that was immediately followed by a $( or ${ block,
+        # that character would disappear from the output
+        proc actual(): string = tmpli js"-$(x)"
+        const expected = js"-5"
+
+        echo actual()
+        assert actual() == expected
+
     block: #forIn
         proc actual: string = tmpli html"""
             <p>Test for</p>


### PR DESCRIPTION
Hello! I recently ran into a minor issue, and thought I'd try my hand at fixing it. Here's an example that fails:
```nim
import templates
proc example(x = 5): string = tmpli js"-$(x)"
assert example() == js"-5"
```
The output is `5`, instead of `-5` as expected. This seems to be caused by the behavior of `trim_eol` when it reaches the first character of its input. In the above example, `trim_eol` will be called on the string `"-"`, immediately reach the first character, and return an empty string, since it hasn't encountered any non-whitespace. The fix is just to reorder so that we check for non-whitespace first, before returning an empty string. I added a regression test for this as well.

I also made a commit to remove the deprecated `stmt` and `expr` metatypes, and replace them with `typed` and `untyped` instead.

Let me know if you have any suggestions, I'm new to the language so criticism is welcome :smile: Thanks!